### PR TITLE
simplified memory-buffer allocation

### DIFF
--- a/src/GalaxyBrain.jl
+++ b/src/GalaxyBrain.jl
@@ -12,7 +12,7 @@ macro bf_str(program::String)
     brainfuck_function = quote
         function (; input::Union{IO,AbstractString}="", output::IO=stdout,
                   index::Int=1, memory_size::Int=30000)
-            memory = repeat([zero(UInt8)], memory_size)
+            memory = zeros(UInt8, memory_size)
             characters = input isa AbstractString ? IOBuffer(input) : input
         end
     end


### PR DESCRIPTION
Not sure why you didn't just call `zeros` (or `fill`) here?